### PR TITLE
Added new parser functionality for the upstream price data

### DIFF
--- a/src/strategy-heat-capacitor.js
+++ b/src/strategy-heat-capacitor.js
@@ -80,9 +80,13 @@ module.exports = function (RED) {
       if (msg.payload.hasOwnProperty("priceData")) {
         if (node.hasOwnProperty("priceData")) {
           node.priceData = mergePriceData(node.priceData, msg.payload.priceData);
-          if (node.priceData.length > 72) node.priceData = node.priceData.slice(-72);
         } else {
           node.priceData = msg.payload.priceData;
+        }
+        if (node.priceData.length) {
+          const latestStart = DateTime.fromISO(node.priceData[node.priceData.length - 1].start);
+          const cutoff = latestStart.minus({ hours: 72 });
+          node.priceData = node.priceData.filter((entry) => DateTime.fromISO(entry.start) >= cutoff);
         }
       }
 


### PR DESCRIPTION
A fix to read the dates and fill the minute price data array accordingly. This should fix #235, where 15 min prices is being wrongfully interpreted as 60 min data, yielding incorrect plans.