### PR TITLE
Heat capacitor/test fixes

### DIFF
--- a/test/strategy-heat-capacitor.test.js
+++ b/test/strategy-heat-capacitor.test.js
@@ -11,6 +11,51 @@ const {
 const converted_prices = require("./data/converted-prices.json");
 const decreasing_end_prices = require("./data/tibber-decreasing2-24h.json");
 
+function buildMinutePriceVectorForTests(priceData) {
+  if (!Array.isArray(priceData) || priceData.length === 0) {
+    return { minutePrices: [], startDate: null };
+  }
+
+  const sorted = priceData
+    .slice()
+    .sort((a, b) => DateTime.fromISO(a.start).toMillis() - DateTime.fromISO(b.start).toMillis());
+
+  const minutePrices = [];
+  let previousIntervalMinutes = 60;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const currentStart = DateTime.fromISO(sorted[i].start);
+    let intervalMinutes = previousIntervalMinutes;
+
+    if (sorted[i + 1]) {
+      intervalMinutes = DateTime.fromISO(sorted[i + 1].start).diff(currentStart, "minutes").minutes;
+    } else if (sorted[i].end) {
+      intervalMinutes = DateTime.fromISO(sorted[i].end).diff(currentStart, "minutes").minutes;
+    }
+
+    intervalMinutes = Math.max(1, Math.round(intervalMinutes));
+    previousIntervalMinutes = intervalMinutes;
+
+    for (let m = 0; m < intervalMinutes; m++) {
+      minutePrices.push(sorted[i].value);
+    }
+  }
+
+  return { minutePrices, startDate: DateTime.fromISO(sorted[0].start) };
+}
+
+function buildMinutePricesFromValues(values, startIso) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return [];
+  }
+  const baseDate = startIso ? DateTime.fromISO(startIso) : DateTime.fromISO(converted_prices.priceData[0].start);
+  const priceData = values.map((value, idx) => ({
+    value,
+    start: baseDate.plus({ hours: idx }).toISO(),
+  }));
+  return buildMinutePriceVectorForTests(priceData).minutePrices;
+}
+
 describe("ps-strategy-heat-capacitor-functions", () => {
   let prices, decreasing_24h_prices, start_date, buy_pattern, sell_pattern;
 
@@ -24,15 +69,16 @@ describe("ps-strategy-heat-capacitor-functions", () => {
   const minSavings = 0.1;
 
   before(function () {
-    prices = converted_prices.priceData.slice(0, 1).map((p) => p.value);
-    decreasing_24h_prices = decreasing_end_prices.priceData.slice(0, 1).map((p) => p.value);
-    start_date = DateTime.fromISO(converted_prices.priceData[0].start);
+    const convertedSingleHour = buildMinutePriceVectorForTests(converted_prices.priceData.slice(0, 1));
+    prices = convertedSingleHour.minutePrices;
+    decreasing_24h_prices = buildMinutePriceVectorForTests(decreasing_end_prices.priceData).minutePrices;
+    start_date = convertedSingleHour.startDate;
     buy_pattern = Array(Math.round(timeHeat1C * maxTempAdjustment * 2)).fill(1);
     sell_pattern = Array(Math.round(timeCool1C * maxTempAdjustment * 2)).fill(1);
   });
 
   it("Can calculate procurement opportunities", () => {
-    const my_prices = prices.slice(0, 1);
+    const my_prices = prices.slice();
     const my_buy_pattern = Array(5).fill(1);
     //Calculate what it will cost to procure/sell 1 kWh as a function of time
     let result = calculateOpportunities(my_prices, my_buy_pattern, 1);
@@ -43,7 +89,7 @@ describe("ps-strategy-heat-capacitor-functions", () => {
 
   it("Can find procurement pattern", () => {
     //Use a simple price list
-    const my_prices = [1, 2, 2, 1, 8, 1];
+    const my_prices = buildMinutePricesFromValues([1, 2, 2, 1, 8, 1], start_date.toISO());
 
     const buy_prices = calculateOpportunities(my_prices, buy_pattern, 1);
     const sell_prices = calculateOpportunities(my_prices, sell_pattern, 1);
@@ -57,7 +103,7 @@ describe("ps-strategy-heat-capacitor-functions", () => {
   });
 
   it("DictList test", () => {
-    const my_prices = [1, 2, 2, 1, 8, 1];
+    const my_prices = buildMinutePricesFromValues([1, 2, 2, 1, 8, 1], start_date.toISO());
     const my_buy_sell_indexes = [
       [0, 173],
       [131, 251],
@@ -70,7 +116,7 @@ describe("ps-strategy-heat-capacitor-functions", () => {
   });
 
   it("DictList test at decreasing end", () => {
-    const my_prices = decreasing_end_prices.priceData.map((p) => p.value);
+    const my_prices = decreasing_24h_prices;
     const buy_prices = calculateOpportunities(my_prices, buy_pattern, 1);
     const sell_prices = calculateOpportunities(my_prices, sell_pattern, 1);
 
@@ -91,7 +137,7 @@ describe("ps-strategy-heat-capacitor-functions", () => {
   });
 
   it("Check removal of low benefit buy-sell pairs", () => {
-    const my_prices = [1, 2, 1, 1.05, 1, 2];
+    const my_prices = buildMinutePricesFromValues([1, 2, 1, 1.05, 1, 2], start_date.toISO());
     const buy_prices = calculateOpportunities(my_prices, buy_pattern, 1);
     const sell_prices = calculateOpportunities(my_prices, sell_pattern, 1);
     const my_buy_sell = findBestBuySellPattern(buy_prices, buy_pattern.length, sell_prices, sell_pattern.length);


### PR DESCRIPTION
Adjusted heat-capacitor function tests to fit new price data ingestion. The functions appear to be fine: The tests needed updating to move away from the hourly price data assumption. This should fix most failing tests caused by the fix of issue #239. I still miss some of the node-red environment requirements to run all of the tests so there might be a few failing tests left.